### PR TITLE
Fixed missing Dispose call when using UnityWebRequest

### DIFF
--- a/Runtime/Core/UnityHttpRequestSender.cs
+++ b/Runtime/Core/UnityHttpRequestSender.cs
@@ -12,37 +12,39 @@ namespace AccelByte.Core
     {
         public IEnumerator Send(IHttpRequest request, Action<IHttpResponse, Error> callback, int timeoutMs)
         {
-            UnityWebRequest unityWebRequest = request.GetUnityWebRequest();
-            unityWebRequest.timeout = timeoutMs / 1000;
+            using(UnityWebRequest unityWebRequest = request.GetUnityWebRequest())
+            {
+                unityWebRequest.timeout = timeoutMs / 1000;
 
-            Report.GetHttpRequest(request, unityWebRequest);
+                Report.GetHttpRequest(request, unityWebRequest);
 
-            yield return unityWebRequest.SendWebRequest();
+                yield return unityWebRequest.SendWebRequest();
 
-            Report.GetHttpResponse(unityWebRequest);
+                Report.GetHttpResponse(unityWebRequest);
                 
 #if UNITY_2020_3_OR_NEWER
-            switch (unityWebRequest.result)
-            {
-            case UnityWebRequest.Result.Success:
-            case UnityWebRequest.Result.ProtocolError:
-            case UnityWebRequest.Result.DataProcessingError:
-                callback?.Invoke(unityWebRequest.GetHttpResponse(), null);
-                break;
-            case UnityWebRequest.Result.ConnectionError:
-                callback?.Invoke(null, new Error(ErrorCode.NetworkError));
-                break;
-            }
+                switch (unityWebRequest.result)
+                {
+                case UnityWebRequest.Result.Success:
+                case UnityWebRequest.Result.ProtocolError:
+                case UnityWebRequest.Result.DataProcessingError:
+                    callback?.Invoke(unityWebRequest.GetHttpResponse(), null);
+                    break;
+                case UnityWebRequest.Result.ConnectionError:
+                    callback?.Invoke(null, new Error(ErrorCode.NetworkError));
+                    break;
+                }
 #else
-            if (unityWebRequest.isNetworkError)
-            {
-                callback?.Invoke(null, new Error(ErrorCode.NetworkError));
-            }
-            else
-            {
-                callback?.Invoke(unityWebRequest.GetHttpResponse(), null);
-            }
+                if (unityWebRequest.isNetworkError)
+                {
+                    callback?.Invoke(null, new Error(ErrorCode.NetworkError));
+                }
+                else
+                {
+                    callback?.Invoke(unityWebRequest.GetHttpResponse(), null);
+                }
 #endif
+            }
         }
 
         public void ClearCookies(Uri uri)


### PR DESCRIPTION
Issue: Using Accelbyte SDK to make REST API calls can result in a memory leak.

Callstack:

`A Native Collection has not been disposed, resulting in a memory leak. Allocated from:
Unity.Collections.NativeArray1:.ctor(Byte[], Allocator)
UnityEngine.Networking.UploadHandlerRaw:.ctor(Byte[])
AccelByte.Core.UnityWebRequestExtension:GetUnityWebRequest(IHttpRequest) (at C:\projects\accelbyte-unity-sdk\Runtime\Core\UnityWebRequestExtension.cs:32)
AccelByte.Core.<Send>d__0:MoveNext() (at C:\projects\accelbyte-unity-sdk\Runtime\Core\UnityHttpRequestSender.cs:16)
UnityEngine.SetupCoroutine:InvokeMoveNext(IEnumerator, IntPtr)
UnityEngine.MonoBehaviour:StartCoroutineManaged2(MonoBehaviour, IEnumerator)
UnityEngine.MonoBehaviour:StartCoroutine(IEnumerator)
AccelByte.Core.CoroutineRunner:Run(IEnumerator) (at C:\projects\accelbyte-unity-sdk\Runtime\Core\CoroutineRunner.cs:38)
AccelByte.Api.User:LoginWithDeviceId(ResultCallback) (at C:\projects\accelbyte-unity-sdk\Runtime\Api\User.cs:155)
Accelbyte:Awake() (at Assets\Accelbyte.cs:19)`

See https://docs.unity3d.com/2019.4/Documentation/ScriptReference/Networking.UnityWebRequest.Dispose.html

You must call Dispose once you have finished using a UnityWebRequest object, regardless of whether the request succeeded or failed.

For safety, it is usually a best practice to employ the using statement to ensure that a [UnityWebRequest] is properly cleaned up in case of uncaught exceptions.