### PR TITLE
Fix UrlUtils.SanitizeBaseUrl

### DIFF
--- a/Runtime/Utils/UrlUtils.cs
+++ b/Runtime/Utils/UrlUtils.cs
@@ -16,7 +16,7 @@ namespace AccelByte.Utils
             string retval = null;
             if (baseURL == null)
             {
-                retval = "";
+                return string.Empty;
             }
             if (Regex.IsMatch(baseURL, regexStr))
             {


### PR DESCRIPTION
Calling UrlUtils.SanitizeBaseUrl with a null string no longer throws ArgumentNullException

Original code flow would still pass baseURL (null) to first argument of Regex.IsMatch